### PR TITLE
[BUGFIX] fix fluid viewhelper namespace

### DIFF
--- a/Resources/Private/Templates/AdminPanel/TypesInformation.html
+++ b/Resources/Private/Templates/AdminPanel/TypesInformation.html
@@ -1,5 +1,5 @@
 <html
-    xmlns:f="https://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
     xmlns:schema="http://typo3.org/ns/Brotkrueml/Schema/ViewHelpers"
     data-namespace-typo3-fluid="true"
 >


### PR DESCRIPTION
TYPO3 v13 throws an error if namespace starts with https://

<img width="768" alt="Bildschirmfoto 2024-10-22 um 02 47 20" src="https://github.com/user-attachments/assets/b9103537-693f-4873-b226-23a1c0627c7d">
